### PR TITLE
[IMP] sale_disable_inventory_check: register_hook en _onchange_product_id_check_availability

### DIFF
--- a/sale_disable_inventory_check/models/sale_order_line.py
+++ b/sale_disable_inventory_check/models/sale_order_line.py
@@ -1,20 +1,27 @@
 # Copyright Komit <http://komit-consulting.com>
 # License AGPL-3.0 or later (https://www.gnu.org/licenses/agpl).
 
-from odoo import api, models, _
+from odoo import api, models
+
+
+def _build_patched_onchange():
+    @api.onchange("product_uom_qty", "product_uom", "route_id")
+    def _onchange_product_id_check_availability(self):
+        if (
+            self.product_id
+            and not self.product_id.product_tmpl_id._check_stock_on_sale()
+        ):
+            return {}
+        return _onchange_product_id_check_availability.origin(self)
+    return _onchange_product_id_check_availability
 
 
 class SaleOrderLine(models.Model):
     _inherit = "sale.order.line"
 
-    @api.onchange('product_uom_qty', 'product_uom', 'route_id')
-    def _onchange_product_id_check_availability(self):
-        res = \
-            super(SaleOrderLine,
-                  self)._onchange_product_id_check_availability()
-        if self.product_id \
-                and not self.product_id.product_tmpl_id._check_stock_on_sale():
-            if res.get('warning', {}).get('title') == _(
-                    'Not enough inventory!'):
-                res.pop('warning')
-        return res
+    def _register_hook(self):
+        self.env[self._name]._patch_method(
+            "_onchange_product_id_check_availability",
+            _build_patched_onchange(),
+        )
+        return super()._register_hook()


### PR DESCRIPTION
Con _register_hook, hacer que ejecute antes la comprobación de "Check Stock on Sale" en el método _onchange_product_id_check_availability.

Ref: odoo-11/zennio#334