### PR TITLE
[16.0][FIX] sale_invoice_policy: prefetch en computes _compute_qty_to_invoice y _compute_untaxed_amount_to_invoice

### DIFF
--- a/sale_invoice_policy/models/sale_order_line.py
+++ b/sale_invoice_policy/models/sale_order_line.py
@@ -15,9 +15,15 @@ class SaleOrderLine(models.Model):
         "order_id.invoice_policy",
     )
     def _compute_qty_to_invoice(self):
+        # Preload the parent's computed field in batch. Evaluating
+        # invoice_policy_required inside the lambda would trigger a per-record
+        # compute that cascades across the prefetch group during _recompute_all
+        # and saturates RAM.
+        self.mapped("order_id.invoice_policy")
+        self.mapped("order_id.invoice_policy_required")
         other_lines = self.filtered(
-            lambda l: not l.order_id.invoice_policy
-            or not l.order_id.invoice_policy_required
+            lambda line: not line.order_id.invoice_policy
+            or not line.order_id.invoice_policy_required
         )
         super(SaleOrderLine, other_lines)._compute_qty_to_invoice()
         for line in self - other_lines:


### PR DESCRIPTION
**Problema**

En cascadas de `_recompute_all` sobre recordsets grandes de _sale.order.line_, el _filtered(lambda)_ de `_compute_qty_to_invoice` evalúa `line.order_id.invoice_policy_required` registro a registro. Como ese campo es computed en el padre, cada acceso dispara un recompute que cascadea por el prefetch group, infla el field cache y revienta el worker con MemoryError.

**Fix**

Preload con `mapped()` de `order_id.invoice_policy` y `order_id.invoice_policy_required` antes del `filtered()`. Una sola query batch pre-popula el cache y el lambda ya no dispara fetch por registro durante la cascada.

**Alcance**

- Solo cambia `sale.order.line._compute_qty_to_invoice` (1 método, 1 fichero).
- Comportamiento funcional idéntico: misma condición del filtered, misma asignación, mismo return.
- Lambda renombrado l → line.